### PR TITLE
Add Pollinations.ai support and custom max tokens UI field

### DIFF
--- a/engine/css/app.css
+++ b/engine/css/app.css
@@ -588,7 +588,8 @@
 
 .dark .ae-variations-row label { color: #aaa; }
 
-#variationsInput {
+#variationsInput,
+#maxTokensInput {
   width: 60px;
   padding: 6px 8px;
   border: 1.5px solid #ddd;
@@ -599,7 +600,12 @@
   color: #333;
 }
 
-.dark #variationsInput {
+#maxTokensInput {
+  width: 80px;
+}
+
+.dark #variationsInput,
+.dark #maxTokensInput {
   background: #1e1e1e;
   border-color: #444;
   color: #ddd;

--- a/engine/index.html
+++ b/engine/index.html
@@ -152,9 +152,16 @@ window.AE_CONFIG_PROMISE = (async function applyConfig() {
               </button>
             </div>
 
-            <div class="ae-variations-row" style="margin-top:0;align-self:center">
-              <label for="variationsInput">Variations:</label>
-              <input type="number" id="variationsInput" min="1" max="4" value="2">
+            <div style="margin-left:auto;display:flex;align-items:center;gap:12px">
+              <div class="ae-variations-row" id="maxTokensRow" style="margin:0;align-self:center;display:none">
+                <label for="maxTokensInput">Max tokens:</label>
+                <input type="number" id="maxTokensInput" min="1" max="32000" step="64" value="1024">
+              </div>
+
+              <div class="ae-variations-row" style="margin:0;align-self:center">
+                <label for="variationsInput">Variations:</label>
+                <input type="number" id="variationsInput" min="1" max="4" value="2">
+              </div>
             </div>
           </div>
         </div>

--- a/engine/js/app.js
+++ b/engine/js/app.js
@@ -31,6 +31,7 @@ class ArtsEngine {
       provider:   this.loadPref('provider', 'google'),
       model:      this.loadPref('model', 'gemini-2.5-flash'),
       variations: parseInt(this.loadPref('variations', '1')),
+      maxTokens:  parseInt(this.loadPref('maxTokens', '1024')),
     };
 
     this.init();
@@ -137,6 +138,9 @@ class ArtsEngine {
     const varInput = document.getElementById('variationsInput');
     if (varInput) varInput.value = this.prefs.variations;
 
+    const maxTokensInput = document.getElementById('maxTokensInput');
+    if (maxTokensInput) maxTokensInput.value = this.prefs.maxTokens;
+
     this.syncOutputButtons();
   }
 
@@ -209,6 +213,9 @@ class ArtsEngine {
       if (input) {
         input.placeholder = `Enter a prompt for your ${typeLabel.toLowerCase()}… (Ctrl+Enter to generate)`;
       }
+
+      const maxTokensRow = document.getElementById('maxTokensRow');
+      if (maxTokensRow) maxTokensRow.style.display = type === 'text' ? '' : 'none';
     };
 
     document.querySelectorAll('.ae-type-btn').forEach(btn => {
@@ -232,6 +239,16 @@ class ArtsEngine {
       e.target.value = val;
       this.prefs.variations = val;
       this.savePref('variations', val);
+    });
+
+    // Max tokens input (clamp 1–32000)
+    document.getElementById('maxTokensInput')?.addEventListener('input', e => {
+      let val = Math.max(1, Math.min(32000, parseInt(e.target.value) || 1024));
+      this.prefs.maxTokens = val;
+      this.savePref('maxTokens', val);
+    });
+    document.getElementById('maxTokensInput')?.addEventListener('blur', e => {
+      e.target.value = this.prefs.maxTokens;
     });
 
     // Add scene button
@@ -1055,7 +1072,7 @@ class ArtsEngine {
     const resp = await fetch(`${this.apiBase}/generate/text`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...this.buildProviderHeaders() },
-      body: JSON.stringify({ prompt: scene.prompt, model: this.prefs.model, max_tokens: 1024 }),
+      body: JSON.stringify({ prompt: scene.prompt, model: this.prefs.model, max_tokens: this.prefs.maxTokens }),
     });
     if (!resp.ok) { const e = await resp.json().catch(() => ({})); throw new Error(e.error || `HTTP ${resp.status}`); }
     const data = await resp.json();

--- a/engine/rust-api/Cargo.lock
+++ b/engine/rust-api/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "api_xai",
  "async-trait",
  "axum",
+ "base64",
  "chrono",
  "dotenvy",
  "reqwest",

--- a/engine/rust-api/Cargo.toml
+++ b/engine/rust-api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1.0"
 api_xai = { version = "0.3.0", default-features = false, features = ["enabled", "integration"] }
 async-trait = "0.1"
+base64 = "0.22"
 axum = "0.8"
 dotenvy = "0.15"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/engine/rust-api/src/providers/mod.rs
+++ b/engine/rust-api/src/providers/mod.rs
@@ -1,6 +1,7 @@
 pub mod claude;
 pub mod gemini;
 pub mod openai_compat;
+pub mod pollinations;
 pub mod xai;
 
 use std::sync::Arc;
@@ -100,6 +101,9 @@ pub fn build_provider_dynamic(
             openai_compat::OpenAICompatProvider::new("deepseek", "https://api.deepseek.com", key.to_string())
                 .with_text_model("deepseek-chat"),
         )),
+        "pollinations" => Ok(Arc::new(pollinations::PollinationsProvider::new(
+            key.to_string(),
+        ))),
         other => match base_url {
             Some(url) => {
                 tracing::info!("Unknown provider '{other}' — routing via openai_compat at {url}");

--- a/engine/rust-api/src/providers/pollinations.rs
+++ b/engine/rust-api/src/providers/pollinations.rs
@@ -1,0 +1,150 @@
+/// Pollinations.ai provider — GET-based image generation API.
+///
+/// API: GET https://image.pollinations.ai/prompt/{url-encoded-prompt}
+///   ?model=flux-schnell|z-image-turbo|...&width=&height=&nologo=true
+///
+/// Auth (optional): Authorization: Bearer <token>. Anonymous tier works
+/// without a key but has stricter rate limits. Tokens come from auth.pollinations.ai.
+///
+/// The response body is raw image bytes (PNG/JPEG). We fetch server-side so the
+/// API key never leaves the backend, then return a base64 data URL — the same
+/// shape openai_compat uses for b64_json responses.
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::models::{
+    GenerationResponse, ImageGenerationRequest, ModelSummary, TextGenerationRequest,
+    VideoGenerationRequest,
+};
+use crate::providers::GenerativeModel;
+
+const BASE_URL: &str = "https://image.pollinations.ai/prompt/";
+const DEFAULT_MODEL: &str = "flux-schnell";
+
+pub struct PollinationsProvider {
+    api_key: Option<String>,
+    http_client: reqwest::Client,
+}
+
+impl PollinationsProvider {
+    pub fn new(api_key: String) -> Self {
+        let api_key = if api_key.trim().is_empty() {
+            None
+        } else {
+            Some(api_key)
+        };
+        Self {
+            api_key,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    /// Map aspect_ratio API string to (width, height) for Pollinations.
+    fn aspect_to_dims(aspect: &str) -> (u32, u32) {
+        match aspect {
+            "16:9" => (1280, 720),
+            "9:16" => (720, 1280),
+            "4:3" => (1152, 864),
+            "3:4" => (864, 1152),
+            _ => (1024, 1024),
+        }
+    }
+}
+
+#[async_trait]
+impl GenerativeModel for PollinationsProvider {
+    fn provider_name(&self) -> &str {
+        "pollinations"
+    }
+
+    async fn list_models(&self) -> anyhow::Result<Vec<ModelSummary>> {
+        Ok(vec![
+            ModelSummary {
+                id: "flux-schnell".to_string(),
+                owned_by: "pollinations".to_string(),
+                created: 0,
+            },
+            ModelSummary {
+                id: "z-image-turbo".to_string(),
+                owned_by: "pollinations".to_string(),
+                created: 0,
+            },
+        ])
+    }
+
+    async fn generate_text(
+        &self,
+        _request: TextGenerationRequest,
+    ) -> anyhow::Result<GenerationResponse> {
+        anyhow::bail!("pollinations does not support text generation via this provider")
+    }
+
+    async fn generate_image(
+        &self,
+        request: ImageGenerationRequest,
+    ) -> anyhow::Result<GenerationResponse> {
+        let model = request.model.as_deref().unwrap_or(DEFAULT_MODEL).to_string();
+        let (width, height) =
+            Self::aspect_to_dims(request.aspect_ratio.as_deref().unwrap_or("1:1"));
+
+        let mut url = reqwest::Url::parse(BASE_URL)?;
+        url.path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("invalid pollinations base url"))?
+            .push(&request.prompt);
+        url.query_pairs_mut()
+            .append_pair("model", &model)
+            .append_pair("width", &width.to_string())
+            .append_pair("height", &height.to_string())
+            .append_pair("nologo", "true");
+
+        let mut req = self.http_client.get(url.clone());
+        if let Some(key) = &self.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        let resp = req.send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("pollinations API error ({status}): {body}");
+        }
+
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("image/png")
+            .to_string();
+        let bytes = resp.bytes().await?;
+
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        let data_url = format!("data:{content_type};base64,{b64}");
+
+        Ok(GenerationResponse {
+            provider: "pollinations".to_string(),
+            model,
+            status: "completed".to_string(),
+            id: None,
+            text: None,
+            usage: None,
+            media_urls: vec![data_url],
+            raw: json!({
+                "source_url": url.to_string(),
+                "content_type": content_type,
+                "byte_length": bytes.len(),
+            }),
+        })
+    }
+
+    async fn generate_video(
+        &self,
+        _request: VideoGenerationRequest,
+    ) -> anyhow::Result<GenerationResponse> {
+        anyhow::bail!("pollinations does not support video generation")
+    }
+
+    async fn video_status(&self, _id: &str) -> anyhow::Result<GenerationResponse> {
+        anyhow::bail!("pollinations does not support video generation")
+    }
+}


### PR DESCRIPTION
Added Pollinations.ai as a image provider with Flux Schnell and Z-Image Turbo models (dedicated GET-based backend that returns base64 data URLs and supports optional bearer auth).
 
Added a Max tokens UI field next to Variations, shown for Text output and wired to
/api/generate/text so users can override the previously hardcoded 1024-token cap.