### PR TITLE
Enhance Node Canvas persistence, 3D preview, and workflow controls

### DIFF
--- a/engine/css/app.css
+++ b/engine/css/app.css
@@ -885,6 +885,80 @@
   margin-top: 2px;
 }
 
+.ae-node-edit-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.ae-node-edit-save,
+.ae-node-edit-cancel {
+  flex: 1;
+  padding: 5px 8px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    color 0.18s ease, transform 0.18s ease;
+}
+
+.ae-node-edit-save {
+  background: #4a90e2;
+  color: #fff;
+}
+
+.ae-node-edit-save:hover {
+  background: #357abd;
+}
+
+.ae-node-edit-cancel {
+  border-color: #cbd5e1;
+  background: #fff;
+  color: #64748b;
+}
+
+.ae-node-edit-cancel:hover {
+  border-color: #94a3b8;
+  background: #f1f5f9;
+  color: #334155;
+}
+
+.ae-node-edit-save:hover,
+.ae-node-edit-cancel:hover {
+  transform: translateY(-1px);
+}
+
+.ae-node-edit-save:focus-visible,
+.ae-node-edit-cancel:focus-visible {
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
+}
+
+.dark .ae-node-edit-save {
+  background: #6aacf5;
+  color: #172033;
+}
+
+.dark .ae-node-edit-save:hover {
+  background: #86bcf7;
+}
+
+.dark .ae-node-edit-cancel {
+  border-color: #4b5563;
+  background: #2a2a2a;
+  color: #cbd5e1;
+}
+
+.dark .ae-node-edit-cancel:hover {
+  border-color: #64748b;
+  background: #333;
+  color: #fff;
+}
+
 /* Arrow connector between nodes */
 .ae-node-arrow {
   display: flex;

--- a/engine/css/node-canvas.css
+++ b/engine/css/node-canvas.css
@@ -4,6 +4,43 @@
    Mounted into #nodeCanvasMount in engine/index.html.
    =========================================================================== */
 
+.nc-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.nc-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 9px;
+  border: 1px solid rgba(0,0,0,0.16);
+  border-radius: 7px;
+  background: #fff;
+  color: #3a7bc8;
+  font: inherit;
+  font-size: 0.74rem;
+  cursor: pointer;
+}
+.nc-panel-toggle:hover { background: #f1f5f9; }
+.nc-panel-toggle .material-icons { font-size: 0.95rem; }
+.nc-panel-collapsed .nc-panel-heading { margin-bottom: 0; }
+.nc-panel-collapsed .nc-panel-content { display: none; }
+.dark .nc-panel-toggle {
+  border-color: rgba(255,255,255,0.2);
+  background: #2a2a2a;
+  color: #8fc2ff;
+}
+.dark .nc-panel-toggle:hover { background: #343a44; }
+
+.nc-model-links {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .nc-toolbar {
   display: flex;
   align-items: center;
@@ -51,6 +88,69 @@
   touch-action: none;
 }
 .nc-viewport.nc-panning { cursor: grabbing; }
+
+.nc-zoom-controls {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid rgba(0,0,0,0.16);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.94);
+  box-shadow: 0 3px 12px rgba(0,0,0,0.12);
+}
+.nc-zoom-controls button {
+  width: 34px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #334155;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.nc-zoom-controls button:hover { background: #eef2f7; }
+.nc-zoom-level {
+  min-width: 48px;
+  color: #64748b;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  pointer-events: none;
+}
+
+.nc-minimap {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 10;
+  width: 180px;
+  height: 120px;
+  overflow: hidden;
+  border: 1px solid rgba(0,0,0,0.18);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.94);
+  box-shadow: 0 3px 12px rgba(0,0,0,0.12);
+  cursor: crosshair;
+}
+.nc-minimap canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.dark .nc-zoom-controls,
+.dark .nc-minimap {
+  border-color: rgba(255,255,255,0.2);
+  background: rgba(35,35,35,0.94);
+}
+.dark .nc-zoom-controls button { color: #e2e8f0; }
+.dark .nc-zoom-controls button:hover { background: #343a44; }
+.dark .nc-zoom-level { color: #aab4c3; }
 
 .nc-world { position: absolute; top: 0; left: 0; width: 100%; height: 100%; transform-origin: 0 0; }
 .nc-edges { position: absolute; top: 0; left: 0; width: 1px; height: 1px; overflow: visible; pointer-events: none; }
@@ -144,6 +244,50 @@
 .nc-output { margin-top: 9px; border-radius: 8px; overflow: hidden; position: relative; background: #f0f1f3; }
 .nc-output img { width: 100%; display: block; cursor: zoom-in; }
 .nc-output-empty { min-height: 40px; display: flex; align-items: center; justify-content: center; color: #bbb; font-size: 0.72rem; }
+.nc-output-empty.nc-generating { gap: 8px; }
+.nc-elapsed { font-variant-numeric: tabular-nums; }
+.nc-model-output {
+  position: relative;
+  background-color: #e8edf3;
+  background-image:
+    linear-gradient(45deg, rgba(100,116,139,0.08) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(100,116,139,0.08) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(100,116,139,0.08) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(100,116,139,0.08) 75%);
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+  background-size: 16px 16px;
+}
+.nc-model-output model-viewer {
+  display: block;
+  width: 100%;
+  height: 220px;
+  background: transparent;
+  --poster-color: #e8edf3;
+}
+.nc-model-status {
+  position: absolute;
+  top: 96px;
+  left: 10px;
+  right: 10px;
+  color: #64748b;
+  font-size: 0.72rem;
+  text-align: center;
+  pointer-events: none;
+}
+.nc-model-status.error {
+  color: #b42318;
+  font-weight: 600;
+}
+.nc-model-output a {
+  display: block;
+  padding: 7px 9px;
+  background: #252525;
+  color: #8fc2ff;
+  font-size: 0.72rem;
+  text-align: center;
+  text-decoration: none;
+}
+.nc-model-output a:hover { text-decoration: underline; }
 .nc-spin { width: 18px; height: 18px; border: 2px solid rgba(74,144,226,0.3); border-top-color: #4a90e2; border-radius: 50%; animation: nc-spin 0.8s linear infinite; }
 @keyframes nc-spin { to { transform: rotate(360deg); } }
 

--- a/engine/index.html
+++ b/engine/index.html
@@ -332,23 +332,31 @@ window.AE_CONFIG_PROMISE = (async function applyConfig() {
         </div>
       </div>
      <!-- Node Canvas — draggable scene flowchart (ComfyUI / Flora style) -->
-      <div class="ae-panel" id="nodeCanvasPanel">
-        <h3>
-          <span class="material-icons" style="font-size:1rem;vertical-align:middle;margin-right:4px">hub</span>
-          Node Canvas
-          <span style="font-size:0.72rem;font-weight:400;color:#aaa;margin-left:6px">beta</span>
+      <div class="ae-panel nc-panel-collapsed" id="nodeCanvasPanel">
+        <h3 class="nc-panel-heading">
+          <span>
+            <span class="material-icons" style="font-size:1rem;vertical-align:middle;margin-right:4px">hub</span>
+            Node Canvas
+            <span style="font-size:0.72rem;font-weight:400;color:#aaa;margin-left:6px">beta</span>
+          </span>
+          <button class="nc-panel-toggle" id="nodeCanvasToggle" type="button" aria-expanded="false" aria-controls="nodeCanvasContent">
+            <span class="material-icons">open_in_full</span>
+            <span class="nc-panel-toggle-label">Open Canvas</span>
+          </button>
         </h3>
-        <p style="margin:0 0 12px 0;font-size:0.85rem;color:#888">
-          Flora-style flow built from separate nodes: a <strong>Text</strong> node (prompt),
-          an <strong>Image</strong> node (upload), and a <strong>Generate</strong> node with its own
-          <strong>model dropdown</strong> — the node adapts to the chosen model: the orange image-input
-          port appears only when the model supports image input, and the output type (image / text / video / 3D)
-          follows the model's capabilities. Wire an output port (●) to a matching input port
-          (purple = text, orange = image); a Generate output can feed another node. Click <strong>Next</strong>
-          to auto-chain a follow-up scene. Generated images also appear below in the Storyboard Flow.
-          Uses the provider keys from "My Model Keys" above.
-        </p>
-        <div id="nodeCanvasMount"></div>
+        <div class="nc-panel-content" id="nodeCanvasContent">
+          <p style="margin:0 0 12px 0;font-size:0.85rem;color:#888">
+            Flora-style flow built from separate nodes: a <strong>Text</strong> node (prompt),
+            an <strong>Image</strong> node (upload), and a <strong>Generate</strong> node with its own
+            <strong>model dropdown</strong> — the node adapts to the chosen model: the orange image-input
+            port appears only when the model supports image input, and the output type (image / text / video / 3D)
+            follows the model's capabilities. Wire an output port (●) to a matching input port
+            (purple = text, orange = image); a Generate output can feed another node. Click <strong>Next</strong>
+            to auto-chain a follow-up scene. Generated images also appear below in the Storyboard Flow.
+            Uses the provider keys from "My Model Keys" above.
+          </p>
+          <div id="nodeCanvasMount"></div>
+        </div>
       </div>
 
       <!-- Storyboard Flowchart Panel -->

--- a/engine/js/app.js
+++ b/engine/js/app.js
@@ -23,6 +23,10 @@ class ArtsEngine {
     this._lastActivity = Date.now();
     this._healthProvider = '';
     this._healthOfflineSince = 0;
+    this._storyboardDbPromise = null;
+    this._storyboardSaveTimer = null;
+    this._storyboardPersistenceReady = false;
+    window.addEventListener('pagehide', () => this.saveStoryboardState());
 
     // Preferences (persisted to localStorage with ae_ prefix)
     this.prefs = {
@@ -113,9 +117,17 @@ class ArtsEngine {
     this.initModelTrigger();
     this.bindEvents();
     this.restorePrefs();
-    this.renderStoryboard();
     this.initGitHubWidget();
-    this.loadDefaultCSV();
+    this.restoreStoryboardState().then(restored => {
+      this._storyboardPersistenceReady = true;
+      this.renderPromptList();
+      this.renderStoryboard();
+      if (restored && this.selectedSceneIdx !== null && this.scenes[this.selectedSceneIdx - 1]) {
+        this.selectScene(this.selectedSceneIdx - 1);
+      } else if (!restored) {
+        this.loadDefaultCSV();
+      }
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -128,6 +140,72 @@ class ArtsEngine {
 
   savePref(key, val) {
     localStorage.setItem('ae_' + key, String(val));
+  }
+
+  openStoryboardDb() {
+    if (this._storyboardDbPromise) return this._storyboardDbPromise;
+    this._storyboardDbPromise = new Promise((resolve, reject) => {
+      if (!window.indexedDB) {
+        reject(new Error('IndexedDB is unavailable'));
+        return;
+      }
+      const request = window.indexedDB.open('arts-engine-storyboard', 1);
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains('state')) {
+          request.result.createObjectStore('state');
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    return this._storyboardDbPromise;
+  }
+
+  async restoreStoryboardState() {
+    try {
+      const db = await this.openStoryboardDb();
+      const state = await new Promise((resolve, reject) => {
+        const request = db.transaction('state', 'readonly').objectStore('state').get('current');
+        request.onsuccess = () => resolve(request.result ?? null);
+        request.onerror = () => reject(request.error);
+      });
+      if (!state || state.version !== 1 || !Array.isArray(state.scenes)) return false;
+      this.scenes = state.scenes;
+      this.selectedSceneIdx = Number.isInteger(state.selectedSceneIdx)
+        ? state.selectedSceneIdx
+        : null;
+      return true;
+    } catch (err) {
+      console.warn('Storyboard state could not be restored:', err);
+      return false;
+    }
+  }
+
+  scheduleStoryboardSave() {
+    if (!this._storyboardPersistenceReady) return;
+    clearTimeout(this._storyboardSaveTimer);
+    this._storyboardSaveTimer = setTimeout(() => this.saveStoryboardState(), 150);
+  }
+
+  async saveStoryboardState() {
+    if (!this._storyboardPersistenceReady) return;
+    try {
+      const db = await this.openStoryboardDb();
+      const state = {
+        version: 1,
+        scenes: this.scenes,
+        selectedSceneIdx: this.selectedSceneIdx,
+      };
+      await new Promise((resolve, reject) => {
+        const transaction = db.transaction('state', 'readwrite');
+        transaction.objectStore('state').put(state, 'current');
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+      });
+    } catch (err) {
+      console.warn('Storyboard state could not be saved:', err);
+    }
   }
 
   restorePrefs() {
@@ -492,6 +570,7 @@ class ArtsEngine {
     // Scroll to node in storyboard
     const node = document.querySelector(`.ae-node-card[data-idx="${idx}"]`);
     if (node) node.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    this.scheduleStoryboardSave();
   }
   
   removeScene(idx) {
@@ -717,6 +796,7 @@ class ArtsEngine {
   renderStoryboard() {
     const container = document.getElementById('storyboardContainer');
     if (!container) return;
+    this.scheduleStoryboardSave();
 
     if (!this.scenes.length) {
       container.innerHTML = `
@@ -795,9 +875,10 @@ class ArtsEngine {
       const active = p.models.filter(m => m.active !== false);
       if (!active.length) continue;
       result[p.id] = active.map(m => ({
-        value: m.id,
+        value: p.id === 'pollinations' && m.id === 'flux-2-klein' ? 'klein' : m.id,
         label: m.name,
         outputs: ['text', ...(m.outputs || [])],
+        imageInput: m.imageInput === true,
         apiModel: m.apiModel,           // exact id/version for the provider API (config-driven)
         apiMode: m.apiMode,             // which task3d.modes entry this model uses
         noCreditsHint: m.noCreditsHint, // message shown when the account has no credits
@@ -885,7 +966,11 @@ class ArtsEngine {
 
   _syncModelPref() {
     const models = ArtsEngine.PROVIDER_MODELS[this.prefs.provider] || ArtsEngine.PROVIDER_MODELS.env;
-    const saved  = this.loadPref('model_' + this.prefs.provider, models[0].value);
+    let saved = this.loadPref('model_' + this.prefs.provider, models[0].value);
+    if (this.prefs.provider === 'pollinations' && saved === 'flux-2-klein') {
+      saved = 'klein';
+      this.savePref('model_pollinations', saved);
+    }
     this.prefs.model = models.find(m => m.value === saved) ? saved : models[0].value;
     this.syncOutputButtons();
   }
@@ -1157,6 +1242,7 @@ class ArtsEngine {
     this.lastRaw = data;
     this.renderRawPanel();
     if (this.scenes[sceneIdx]) this.scenes[sceneIdx].text = data.text || '';
+    this.scheduleStoryboardSave();
     this.appendTextResult(scene.prompt, data.text || '');
   }
 

--- a/engine/js/node-canvas.js
+++ b/engine/js/node-canvas.js
@@ -29,6 +29,9 @@
   ];
   // Output kinds we can render, in preference order for a model's default.
   const OUTPUT_ORDER = ["image", "video", "3d", "text"];
+  const STATE_DB = "arts-engine-node-canvas";
+  const STATE_STORE = "workspace";
+  const STATE_KEY = "current";
 
   let SEQ = 0;
   const getAE = () =>
@@ -50,9 +53,31 @@
       this.zoom = 1;
       this.selectedId = null;
       this._connecting = null;
+      this._persistReady = false;
+      this._saveTimer = null;
+      this._dbPromise = null;
       this._build();
+      this._bindPanelToggle();
       this._bindGlobal();
-      this._seed();
+      this._restoreState().then((restored) => {
+        if (!restored) this._seed();
+        this._persistReady = true;
+        this._saveState();
+      }).catch((err) => {
+        console.warn("Node Canvas restore failed:", err);
+        this._seed();
+        this._persistReady = true;
+        this._saveState();
+      });
+      window.addEventListener("pagehide", () => this._saveState());
+      (window.AE_CONFIG_PROMISE || Promise.resolve()).then(() => {
+        const ae = getAE();
+        if (ae && window.AE_API_BASE)
+          ae.apiBase = window.AE_API_BASE.replace(/\/$/, "") + "/api";
+        this.nodes.forEach((node) => {
+          if (node.output3d) this._renderOutput(node);
+        });
+      });
     }
 
     _seed() {
@@ -60,6 +85,169 @@
       const g = this.addNode("generate", { x: 320, y: 70 });
       this.addNode("image", { x: 30, y: 250 });
       this.connect(t.id, g.id, "prompt", "text");
+    }
+
+    _bindPanelToggle() {
+      const panel = this.mount.closest("#nodeCanvasPanel");
+      const toggle = panel?.querySelector("#nodeCanvasToggle");
+      if (!panel || !toggle) return;
+      const storageKey = "arts-engine-node-canvas-expanded";
+      let expanded = false;
+      try {
+        expanded = window.localStorage.getItem(storageKey) === "true";
+      } catch (_) {}
+
+      const setExpanded = (isExpanded) => {
+        panel.classList.toggle("nc-panel-collapsed", !isExpanded);
+        toggle.setAttribute("aria-expanded", String(isExpanded));
+        const icon = toggle.querySelector(".material-icons");
+        const label = toggle.querySelector(".nc-panel-toggle-label");
+        if (icon)
+          icon.textContent = isExpanded ? "close_fullscreen" : "open_in_full";
+        if (label) label.textContent = isExpanded ? "Minimize" : "Open Canvas";
+      };
+
+      setExpanded(expanded);
+      toggle.addEventListener("click", () => {
+        expanded = panel.classList.contains("nc-panel-collapsed");
+        setExpanded(expanded);
+        try {
+          window.localStorage.setItem(storageKey, String(expanded));
+        } catch (_) {}
+        if (expanded) {
+          requestAnimationFrame(() => {
+            this._applyWorld();
+            this._drawEdges();
+          });
+        }
+      });
+    }
+
+    // ---- persistence ------------------------------------------------------
+    _openStateDb() {
+      if (this._dbPromise) return this._dbPromise;
+      this._dbPromise = new Promise((resolve, reject) => {
+        if (!window.indexedDB) {
+          reject(new Error("IndexedDB is unavailable"));
+          return;
+        }
+        const req = window.indexedDB.open(STATE_DB, 1);
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains(STATE_STORE))
+            req.result.createObjectStore(STATE_STORE);
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+      return this._dbPromise;
+    }
+
+    async _readSavedState() {
+      try {
+        const db = await this._openStateDb();
+        return await new Promise((resolve, reject) => {
+          const req = db
+            .transaction(STATE_STORE, "readonly")
+            .objectStore(STATE_STORE)
+            .get(STATE_KEY);
+          req.onsuccess = () => resolve(req.result ?? null);
+          req.onerror = () => reject(req.error);
+        });
+      } catch (err) {
+        console.warn("Node Canvas state could not be loaded:", err);
+        return null;
+      }
+    }
+
+    _snapshot() {
+      const nodes = [...this.nodes.values()].map((node) => ({
+        id: node.id,
+        type: node.type,
+        x: node.x,
+        y: node.y,
+        text: node.text || "",
+        uploadImage: node.uploadImage || null,
+        outputImage: node.outputImage || null,
+        outputText: node.outputText || null,
+        output3d: node.output3d || null,
+        output3dPoster: node.output3dPoster || null,
+        provider: node.provider,
+        model: node.model,
+        outputType: node.outputType,
+        ratio: node.ratio,
+        instructions: node.instructions || "",
+      }));
+      return {
+        version: 1,
+        seq: SEQ,
+        pan: this.pan,
+        zoom: this.zoom,
+        selectedId: this.selectedId,
+        nodes,
+        edges: this.edges.map((edge) => ({ ...edge })),
+      };
+    }
+
+    async _saveState() {
+      if (!this._persistReady) return;
+      try {
+        const db = await this._openStateDb();
+        const state = this._snapshot();
+        await new Promise((resolve, reject) => {
+          const tx = db.transaction(STATE_STORE, "readwrite");
+          tx.objectStore(STATE_STORE).put(state, STATE_KEY);
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error);
+          tx.onabort = () => reject(tx.error);
+        });
+      } catch (err) {
+        console.warn("Node Canvas state could not be saved:", err);
+      }
+    }
+
+    _scheduleSave() {
+      if (!this._persistReady) return;
+      clearTimeout(this._saveTimer);
+      this._saveTimer = setTimeout(() => this._saveState(), 150);
+    }
+
+    async _restoreState() {
+      const state = await this._readSavedState();
+      if (!state || state.version !== 1 || !Array.isArray(state.nodes))
+        return false;
+
+      if (Number.isFinite(state.pan?.x) && Number.isFinite(state.pan?.y))
+        this.pan = { x: state.pan.x, y: state.pan.y };
+      if (Number.isFinite(state.zoom))
+        this.zoom = Math.min(1.5, Math.max(0.1, state.zoom));
+
+      for (const saved of state.nodes) {
+        if (!saved?.id || !["text", "image", "generate"].includes(saved.type))
+          continue;
+        const node = {
+          ...saved,
+          x: Number.isFinite(saved.x) ? saved.x : 60,
+          y: Number.isFinite(saved.y) ? saved.y : 60,
+          generating: false,
+          _error: null,
+        };
+        this.nodes.set(node.id, node);
+        this._createNodeEl(node);
+        this._positionNode(node);
+        const numericId = Number.parseInt(node.id.replace(/^n/, ""), 10);
+        if (Number.isFinite(numericId)) SEQ = Math.max(SEQ, numericId);
+      }
+      if (Number.isFinite(state.seq)) SEQ = Math.max(SEQ, state.seq);
+
+      this.edges = (Array.isArray(state.edges) ? state.edges : []).filter(
+        (edge) => this.nodes.has(edge.from) && this.nodes.has(edge.to),
+      );
+      this._applyWorld();
+      this._refreshPorts();
+      this._drawEdges();
+      if (state.selectedId && this.nodes.has(state.selectedId))
+        this.selectNode(state.selectedId);
+      return true;
     }
 
     // ---- model registry helpers -----------------------------------------
@@ -136,10 +324,36 @@
           <button class="nc-btn" data-act="clear"><span class="material-icons">clear_all</span>Clear</button>
           <span class="nc-hint">Pick a model per Generate node · ports adapt to it · purple = text, orange = image</span>
         </div>
-        <div class="nc-viewport"><div class="nc-world"><svg class="nc-edges"><g></g></svg></div></div>`;
+        <div class="nc-viewport">
+          <div class="nc-world"><svg class="nc-edges"><g></g></svg></div>
+          <div class="nc-zoom-controls" aria-label="Canvas zoom controls">
+            <button type="button" data-zoom="out" title="Zoom out" aria-label="Zoom out">−</button>
+            <span class="nc-zoom-level">100%</span>
+            <button type="button" data-zoom="in" title="Zoom in" aria-label="Zoom in">+</button>
+          </div>
+          <div class="nc-minimap" title="Click to navigate the canvas">
+            <canvas aria-label="Workflow minimap"></canvas>
+          </div>
+        </div>`;
       this.viewport = this.mount.querySelector(".nc-viewport");
       this.world = this.mount.querySelector(".nc-world");
       this.edgeLayer = this.mount.querySelector(".nc-edges g");
+      this.zoomLevel = this.mount.querySelector(".nc-zoom-level");
+      this.minimap = this.mount.querySelector(".nc-minimap");
+      this.minimapCanvas = this.minimap.querySelector("canvas");
+
+      this.mount.querySelector('[data-zoom="out"]').onclick = (e) => {
+        e.stopPropagation();
+        this._zoomBy(1 / 1.2);
+      };
+      this.mount.querySelector('[data-zoom="in"]').onclick = (e) => {
+        e.stopPropagation();
+        this._zoomBy(1.2);
+      };
+      this.minimap.addEventListener("pointerdown", (e) => {
+        e.stopPropagation();
+        this._navigateFromMinimap(e);
+      });
 
       this.mount.querySelectorAll("[data-add]").forEach((b) => {
         b.onclick = () => {
@@ -148,10 +362,8 @@
         };
       });
       this.mount.querySelector('[data-act="reset"]').onclick = () => {
-        this.pan = { x: 30, y: 24 };
-        this.zoom = 1;
-        this._applyWorld();
-        this._drawEdges();
+        this._fitView();
+        this._scheduleSave();
       };
       this.mount.querySelector('[data-act="clear"]').onclick = () => {
         if (!confirm("Remove all nodes from the canvas?")) return;
@@ -160,6 +372,9 @@
         this.nodeEls.clear();
         this.world.querySelectorAll(".nc-node").forEach((el) => el.remove());
         this._drawEdges();
+        this.selectedId = null;
+        clearTimeout(this._saveTimer);
+        this._saveState();
       };
       this._applyWorld();
     }
@@ -168,6 +383,176 @@
       const arr = [...this.nodes.values()];
       const last = arr[arr.length - 1];
       return last ? { x: last.x + 36, y: last.y + 36 } : { x: 40, y: 40 };
+    }
+
+    _fitView() {
+      if (!this.nodes.size) {
+        this.pan = { x: 30, y: 24 };
+        this.zoom = 1;
+        this._applyWorld();
+        this._drawEdges();
+        return;
+      }
+
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      this.nodes.forEach((node, id) => {
+        const el = this.nodeEls.get(id);
+        minX = Math.min(minX, node.x);
+        minY = Math.min(minY, node.y);
+        maxX = Math.max(maxX, node.x + (el?.offsetWidth || 220));
+        maxY = Math.max(maxY, node.y + (el?.offsetHeight || 160));
+      });
+
+      const padding = 32;
+      const viewportWidth = this.viewport.clientWidth;
+      const viewportHeight = this.viewport.clientHeight;
+      const contentWidth = Math.max(1, maxX - minX);
+      const contentHeight = Math.max(1, maxY - minY);
+      const availableWidth = Math.max(1, viewportWidth - padding * 2);
+      const availableHeight = Math.max(1, viewportHeight - padding * 2);
+      this.zoom = Math.min(
+        1.5,
+        Math.max(
+          0.1,
+          Math.min(availableWidth / contentWidth, availableHeight / contentHeight),
+        ),
+      );
+      this.pan = {
+        x: (viewportWidth - contentWidth * this.zoom) / 2 - minX * this.zoom,
+        y: (viewportHeight - contentHeight * this.zoom) / 2 - minY * this.zoom,
+      };
+      this._applyWorld();
+      this._drawEdges();
+    }
+
+    _zoomBy(factor) {
+      const cx = this.viewport.clientWidth / 2;
+      const cy = this.viewport.clientHeight / 2;
+      const worldX = (cx - this.pan.x) / this.zoom;
+      const worldY = (cy - this.pan.y) / this.zoom;
+      const next = Math.min(1.5, Math.max(0.1, this.zoom * factor));
+      this.zoom = next;
+      this.pan = {
+        x: cx - worldX * next,
+        y: cy - worldY * next,
+      };
+      this._applyWorld();
+      this._drawEdges();
+      this._scheduleSave();
+    }
+
+    _navigateFromMinimap(e) {
+      const map = this._minimapTransform;
+      if (!map) return;
+      const rect = this.minimapCanvas.getBoundingClientRect();
+      const worldX = (e.clientX - rect.left - map.offsetX) / map.scale + map.minX;
+      const worldY = (e.clientY - rect.top - map.offsetY) / map.scale + map.minY;
+      this.pan = {
+        x: this.viewport.clientWidth / 2 - worldX * this.zoom,
+        y: this.viewport.clientHeight / 2 - worldY * this.zoom,
+      };
+      this._applyWorld();
+      this._drawEdges();
+      this._scheduleSave();
+    }
+
+    _drawMinimap() {
+      const canvas = this.minimapCanvas;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const width = rect.width;
+      const height = rect.height;
+      if (!width || !height) return;
+      const dpr = window.devicePixelRatio || 1;
+      const pixelWidth = Math.round(width * dpr);
+      const pixelHeight = Math.round(height * dpr);
+      if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+        canvas.width = pixelWidth;
+        canvas.height = pixelHeight;
+      }
+      const ctx = canvas.getContext("2d");
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+
+      const view = {
+        x: -this.pan.x / this.zoom,
+        y: -this.pan.y / this.zoom,
+        width: this.viewport.clientWidth / this.zoom,
+        height: this.viewport.clientHeight / this.zoom,
+      };
+      let minX = view.x;
+      let minY = view.y;
+      let maxX = view.x + view.width;
+      let maxY = view.y + view.height;
+      this.nodes.forEach((node, id) => {
+        const el = this.nodeEls.get(id);
+        minX = Math.min(minX, node.x);
+        minY = Math.min(minY, node.y);
+        maxX = Math.max(maxX, node.x + (el?.offsetWidth || 220));
+        maxY = Math.max(maxY, node.y + (el?.offsetHeight || 160));
+      });
+
+      const mapPadding = 7;
+      const boundsWidth = Math.max(1, maxX - minX);
+      const boundsHeight = Math.max(1, maxY - minY);
+      const scale = Math.min(
+        (width - mapPadding * 2) / boundsWidth,
+        (height - mapPadding * 2) / boundsHeight,
+      );
+      const offsetX = (width - boundsWidth * scale) / 2;
+      const offsetY = (height - boundsHeight * scale) / 2;
+      this._minimapTransform = { minX, minY, scale, offsetX, offsetY };
+      const px = (x) => offsetX + (x - minX) * scale;
+      const py = (y) => offsetY + (y - minY) * scale;
+
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = "rgba(100, 116, 139, 0.45)";
+      for (const edge of this.edges) {
+        const from = this.nodes.get(edge.from);
+        const to = this.nodes.get(edge.to);
+        if (!from || !to) continue;
+        const fromEl = this.nodeEls.get(from.id);
+        const toEl = this.nodeEls.get(to.id);
+        ctx.beginPath();
+        ctx.moveTo(
+          px(from.x + (fromEl?.offsetWidth || 220) / 2),
+          py(from.y + (fromEl?.offsetHeight || 160) / 2),
+        );
+        ctx.lineTo(
+          px(to.x + (toEl?.offsetWidth || 220) / 2),
+          py(to.y + (toEl?.offsetHeight || 160) / 2),
+        );
+        ctx.stroke();
+      }
+
+      const colors = {
+        text: "#7c5cff",
+        image: "#e2914a",
+        generate: "#4a90e2",
+      };
+      this.nodes.forEach((node, id) => {
+        const el = this.nodeEls.get(id);
+        ctx.fillStyle = colors[node.type] || "#64748b";
+        ctx.fillRect(
+          px(node.x),
+          py(node.y),
+          Math.max(3, (el?.offsetWidth || 220) * scale),
+          Math.max(3, (el?.offsetHeight || 160) * scale),
+        );
+      });
+
+      ctx.strokeStyle = "#2563eb";
+      ctx.lineWidth = 1.5;
+      ctx.fillStyle = "rgba(37, 99, 235, 0.08)";
+      const vx = px(view.x);
+      const vy = py(view.y);
+      const vw = view.width * scale;
+      const vh = view.height * scale;
+      ctx.fillRect(vx, vy, vw, vh);
+      ctx.strokeRect(vx, vy, vw, vh);
     }
 
     // ---- node data + DOM --------------------------------------------------
@@ -187,20 +572,25 @@
       };
       if (type === "generate") {
         const def = this._defaultModel();
-        node.provider = opts.provider || def.provider;
-        node.model = opts.model || def.model;
+        const previous = [...this.nodes.values()]
+          .reverse()
+          .find((existing) => existing.type === "generate");
+        node.provider = opts.provider || previous?.provider || def.provider;
+        node.model = opts.model || previous?.model || def.model;
         const cfg = this._modelCfg(node.provider, node.model);
-        node.outputType =
-          opts.outputType &&
-          this._renderableOutputs(cfg).includes(opts.outputType)
-            ? opts.outputType
-            : this._defaultOutputType(cfg);
-        node.ratio = opts.ratio || getAE()?.prefs?.ratio || "square";
+        const inheritedOutput = opts.outputType || previous?.outputType;
+        node.outputType = this._renderableOutputs(cfg).includes(inheritedOutput)
+          ? inheritedOutput
+          : this._defaultOutputType(cfg);
+        node.ratio =
+          opts.ratio || previous?.ratio || getAE()?.prefs?.ratio || "square";
         node.instructions = opts.instructions || "";
       }
       this.nodes.set(id, node);
       this._createNodeEl(node);
       this._positionNode(node);
+      this._drawMinimap();
+      this._scheduleSave();
       return node;
     }
 
@@ -211,6 +601,10 @@
       el.innerHTML = this._nodeMarkup(node);
       this.world.appendChild(el);
       this.nodeEls.set(node.id, el);
+      if (node.output3d) {
+        this._ensureModelViewer();
+        this._wireModelViewer(el.querySelector(".nc-output"));
+      }
       // Root-level listener bound once (survives body rebuilds).
       el.addEventListener("pointerdown", () => this.selectNode(node.id));
       this._wireNodeEl(node, el);
@@ -323,14 +717,28 @@
     }
 
     _outputInner(node) {
-      if (node.generating)
-        return `<div class="nc-output-empty"><span class="nc-spin"></span></div>`;
+      if (node.generating) {
+        const elapsed = Math.max(
+          0,
+          Math.floor((Date.now() - (node._generationStartedAt || Date.now())) / 1000),
+        );
+        const label = node.outputType === "3d" ? "Generating 3D" : "Generating";
+        return `<div class="nc-output-empty nc-generating"><span class="nc-spin"></span><span class="nc-elapsed">${label}… ${this._formatElapsed(elapsed)}</span></div>`;
+      }
       if (node._error)
         return `<div class="nc-output-empty" style="color:#c33">${esc(node._error)}</div>`;
       if (node.outputType === "text" && node.outputText)
         return `<div class="nc-output-text">${esc(node.outputText)}</div>`;
       if (node.output3d) {
-        return `<model-viewer src="${esc(node.output3d)}"${node.output3dPoster ? ` poster="${esc(node.output3dPoster)}"` : ""} camera-controls auto-rotate environment-image="neutral" exposure="1" shadow-intensity="1" tone-mapping="aces" loading="eager" style="width:100%;height:100%;background:#1a1a1a;--poster-color:transparent"></model-viewer>`;
+        const previewUrl = this._modelPreviewUrl(node.output3d);
+        return `<div class="nc-model-output">
+          <model-viewer src="${esc(previewUrl)}"${node.output3dPoster ? ` poster="${esc(node.output3dPoster)}"` : ""} camera-controls auto-rotate auto-rotate-delay="0" environment-image="neutral" exposure="1.25" shadow-intensity="0.8" tone-mapping="aces" loading="eager" interaction-prompt="none"></model-viewer>
+          <div class="nc-model-status">Loading 3D preview…</div>
+          <div class="nc-model-links">
+            <a href="${esc(node.output3d)}" target="_blank" rel="noopener">Open 3D model</a>
+            ${node.output3dPoster ? `<a href="${esc(node.output3dPoster)}" target="_blank" rel="noopener">Open rendered poster</a>` : ""}
+          </div>
+        </div>`;
       }
       if (node.outputImage) {
         return node.outputType === "video"
@@ -338,6 +746,71 @@
           : `<img src="${node.outputImage}" alt="output">`;
       }
       return `<div class="nc-output-empty">no output yet</div>`;
+    }
+
+    _formatElapsed(totalSeconds) {
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+    }
+
+    _modelPreviewUrl(url) {
+      if (!/^https?:\/\//i.test(url)) return url;
+      const apiBase = window.AE_API_BASE
+        ? window.AE_API_BASE.replace(/\/$/, "") + "/api"
+        : getAE()?.apiBase;
+      return apiBase
+        ? `${apiBase}/proxy/model?url=${encodeURIComponent(url)}`
+        : url;
+    }
+
+    _ensureModelViewer() {
+      if (window.customElements?.get("model-viewer")) return;
+      if (document.querySelector("script[data-nc-model-viewer]")) return;
+      const script = document.createElement("script");
+      script.type = "module";
+      script.src = "https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js";
+      script.dataset.ncModelViewer = "1";
+      script.onerror = () => {
+        this._modelViewerFailed = true;
+        this.mount.querySelectorAll(".nc-model-status").forEach((status) => {
+          status.hidden = false;
+          status.textContent =
+            "3D viewer failed to load. Use Open 3D model below.";
+          status.classList.add("error");
+        });
+      };
+      document.head.appendChild(script);
+    }
+
+    _wireModelViewer(root) {
+      const viewer = root?.querySelector("model-viewer");
+      const status = root?.querySelector(".nc-model-status");
+      if (!viewer || !status || viewer.dataset.ncWired) return;
+      viewer.dataset.ncWired = "1";
+      if (this._modelViewerFailed) {
+        status.textContent =
+          "3D viewer failed to load. Use Open 3D model below.";
+        status.classList.add("error");
+      }
+      const timeout = setTimeout(() => {
+        if (status.hidden) return;
+        status.textContent =
+          "3D preview is taking too long. Use Open 3D model below.";
+        status.classList.add("error");
+      }, 30000);
+      viewer.addEventListener("load", () => {
+        clearTimeout(timeout);
+        status.hidden = true;
+        this._drawMinimap();
+      });
+      viewer.addEventListener("error", () => {
+        clearTimeout(timeout);
+        status.hidden = false;
+        status.textContent =
+          "3D preview unavailable. Use Open 3D model below.";
+        status.classList.add("error");
+      });
     }
 
     _wireNodeEl(node, el) {
@@ -358,6 +831,7 @@
         const ta = el.querySelector("textarea");
         ta.addEventListener("input", () => {
           node.text = ta.value;
+          this._scheduleSave();
         });
         ta.addEventListener("pointerdown", (e) => e.stopPropagation());
       } else if (node.type === "image") {
@@ -388,6 +862,7 @@
         if (rt) {
           rt.addEventListener("change", (e) => {
             node.ratio = e.target.value;
+            this._scheduleSave();
           });
           rt.addEventListener("pointerdown", stop);
         }
@@ -395,6 +870,7 @@
         if (instr) {
           instr.addEventListener("input", (e) => {
             node.instructions = e.target.value;
+            this._scheduleSave();
           });
           instr.addEventListener("pointerdown", stop);
         }
@@ -423,7 +899,7 @@
     // connections the new shape can't support.
     _rebuildGenerate(node) {
       const cfg = this._modelCfg(node.provider, node.model);
-      if (!cfg?.imageInput)
+      if (!this._modelSupportsImageInput(node))
         this.edges = this.edges.filter(
           (e) => !(e.to === node.id && e.toPort === "image"),
         );
@@ -436,6 +912,7 @@
       this._wireNodeEl(node, el);
       this._refreshPorts();
       this._drawEdges();
+      this._scheduleSave();
     }
 
     _onUpload(node, input) {
@@ -445,6 +922,7 @@
       r.onload = () => {
         node.uploadImage = r.result;
         this._renderImageSlot(node);
+        this._scheduleSave();
       };
       r.readAsDataURL(f);
     }
@@ -467,19 +945,25 @@
 
     removeNode(id) {
       const node = this.nodes.get(id);
+      if (node?._elapsedTimer) clearInterval(node._elapsedTimer);
       this.edges = this.edges.filter((e) => e.from !== id && e.to !== id);
       this.nodeEls.get(id)?.remove();
       this.nodeEls.delete(id);
       this.nodes.delete(id);
       // Drop its Storyboard scene, if it had one.
       const ae = getAE();
-      if (node?._scene && ae && Array.isArray(ae.scenes)) {
-        const i = ae.scenes.indexOf(node._scene);
+      if (node && ae && Array.isArray(ae.scenes)) {
+        const scene = node._scene || ae.scenes.find((item) =>
+          item?._nodeCanvasId === node.id ||
+          (node.outputImage && item?.image === node.outputImage),
+        );
+        const i = scene ? ae.scenes.indexOf(scene) : -1;
         if (i >= 0) ae.scenes.splice(i, 1);
         if (typeof ae.renderStoryboard === "function") ae.renderStoryboard();
       }
       this._refreshPorts();
       this._drawEdges();
+      this._scheduleSave();
     }
 
     selectNode(id) {
@@ -487,6 +971,7 @@
       this.nodeEls.forEach((el, nid) =>
         el.classList.toggle("nc-selected", nid === id),
       );
+      this._scheduleSave();
     }
 
     // ---- "Next scene" -----------------------------------------------------
@@ -526,6 +1011,7 @@
       this.edges.push({ from: fromId, to: toId, toPort, ptype });
       this._refreshPorts();
       this._drawEdges();
+      this._scheduleSave();
     }
 
     _wouldCycle(fromId, toId) {
@@ -600,6 +1086,49 @@
       return [scene, extra].filter(Boolean).join("\n\n");
     }
 
+    _fillTemplate(value, substitutions) {
+      if (typeof value === "string") {
+        return value.replace(/\{(\w+)\}/g, (match, key) =>
+          key in substitutions ? substitutions[key] : match,
+        );
+      }
+      if (Array.isArray(value))
+        return value.map((item) => this._fillTemplate(item, substitutions));
+      if (value && typeof value === "object") {
+        return Object.fromEntries(
+          Object.entries(value).map(([key, item]) => [
+            key,
+            this._fillTemplate(item, substitutions),
+          ]),
+        );
+      }
+      return value;
+    }
+
+    async _prepareTripoImage(image, apiBase, headers) {
+      if (/^https?:\/\//i.test(image)) {
+        const pathname = new URL(image).pathname.toLowerCase();
+        return {
+          type: pathname.endsWith(".png") ? "png" : "jpg",
+          url: image,
+        };
+      }
+      const response = await fetch(`${apiBase}/upload/tripo`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ image }),
+      });
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || `Tripo upload HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      return {
+        type: data.file_type || "jpg",
+        file_token: data.file_token,
+      };
+    }
+
     getImageInput(genNode) {
       const e = this.edges.find(
         (x) => x.to === genNode.id && x.toPort === "image",
@@ -611,8 +1140,10 @@
         src.type === "generate" &&
         src.outputType !== "text" &&
         src.outputType !== "video"
-      )
+      ) {
+        if (src.outputType === "3d") return src.output3dPoster || null;
         return src.outputImage || null;
+      }
       return null;
     }
 
@@ -636,6 +1167,7 @@
       const up = () => {
         window.removeEventListener("pointermove", move);
         window.removeEventListener("pointerup", up);
+        this._scheduleSave();
       };
       window.addEventListener("pointermove", move);
       window.addEventListener("pointerup", up);
@@ -665,6 +1197,7 @@
           window.removeEventListener("pointermove", move);
           window.removeEventListener("pointerup", up);
           this.viewport.classList.remove("nc-panning");
+          this._scheduleSave();
         };
         window.addEventListener("pointermove", move);
         window.addEventListener("pointerup", up);
@@ -680,13 +1213,14 @@
           const old = this.zoom;
           const next = Math.min(
             1.5,
-            Math.max(0.4, old * (e.deltaY < 0 ? 1.1 : 0.9)),
+            Math.max(0.1, old * (e.deltaY < 0 ? 1.1 : 0.9)),
           );
           this.pan.x = cx - (cx - this.pan.x) * (next / old);
           this.pan.y = cy - (cy - this.pan.y) * (next / old);
           this.zoom = next;
           this._applyWorld();
           this._drawEdges();
+          this._scheduleSave();
         },
         { passive: false },
       );
@@ -694,6 +1228,8 @@
 
     _applyWorld() {
       this.world.style.transform = `translate(${this.pan.x}px, ${this.pan.y}px) scale(${this.zoom})`;
+      if (this.zoomLevel)
+        this.zoomLevel.textContent = `${Math.round(this.zoom * 100)}%`;
     }
 
     _toWorld(clientX, clientY) {
@@ -735,6 +1271,7 @@
         const p1 = this._portCenter(this._connecting.fromId, ".nc-port-out");
         if (p1) this._addPath(p1, tempTo, this._connecting.ptype, true);
       }
+      this._drawMinimap();
     }
 
     _addPath(p1, p2, ptype, temp) {
@@ -773,8 +1310,15 @@
       )
         return;
       if (!node._scene || ae.scenes.indexOf(node._scene) < 0) {
+        node._scene = ae.scenes.find((scene) =>
+          scene?._nodeCanvasId === node.id ||
+          (node.outputImage && scene?.image === node.outputImage),
+        );
+      }
+      if (!node._scene) {
         node._scene = {
           scene: String(ae.scenes.length + 1),
+          _nodeCanvasId: node.id,
           prompt: "",
           aspect_ratio: "",
           style: "",
@@ -783,6 +1327,7 @@
         };
         ae.scenes.push(node._scene);
       }
+      node._scene._nodeCanvasId = node.id;
       node._scene.prompt = this.getPrompt(node) || node._scene.prompt || "";
       node._scene.image = node.outputImage;
       ae.renderStoryboard();
@@ -792,6 +1337,8 @@
       const out = this.nodeEls.get(node.id)?.querySelector(".nc-output");
       if (!out) return;
       out.innerHTML = this._outputInner(node);
+      this._drawMinimap();
+      this._wireModelViewer(out);
       const media = out.querySelector("img");
       if (media)
         media.addEventListener("click", () => {
@@ -841,6 +1388,20 @@
       };
 
       node.generating = true;
+      node._generationStartedAt = Date.now();
+      if (node.outputType === "3d") {
+        node._elapsedTimer = setInterval(() => {
+          if (!node.generating) return;
+          const elapsed = Math.floor(
+            (Date.now() - node._generationStartedAt) / 1000,
+          );
+          const label = this.nodeEls
+            .get(node.id)
+            ?.querySelector(".nc-elapsed");
+          if (label)
+            label.textContent = `Generating 3D… ${this._formatElapsed(elapsed)}`;
+        }, 1000);
+      }
       btn.disabled = true;
       this._renderOutput(node);
 
@@ -882,13 +1443,66 @@
           }
           node.outputImage = url;
         } else if (node.outputType === "3d") {
-          // Image-to-3D when a reference image is connected (Tripo supports it),
-          // otherwise text-to-3D. The backend accepts data: or http(s) URLs.
           const inputImg = this._modelSupportsImageInput(node)
             ? this.getImageInput(node)
             : null;
-          const body = { prompt, model: node.model };
-          if (inputImg) body.image_urls = [inputImg];
+          const modelCfg = this._modelCfg(node.provider, node.model);
+          const providerCfg = (window.KeyManagerProviders || []).find(
+            (provider) => provider.id === node.provider,
+          );
+          const spec = providerCfg?.task3d;
+          if (!spec)
+            throw new Error(
+              `No 3D configuration found for provider "${node.provider}"`,
+            );
+          const useTripoImage = node.provider === "tripo" && !!inputImg;
+          const mode = useTripoImage
+            ? "image_to_model"
+            : modelCfg?.apiMode || modelCfg?.value;
+          let modeSpec = spec.modes?.[mode];
+          if (useTripoImage) {
+            const file = await this._prepareTripoImage(
+              inputImg,
+              apiBase,
+              headers,
+            );
+            modeSpec = {
+              submitPath: "/task",
+              body: {
+                type: "image_to_model",
+                model_version: "{model}",
+                file,
+                texture: true,
+                pbr: true,
+              },
+            };
+          }
+          if (!modeSpec)
+            throw new Error(
+              `3D mode "${mode}" is not configured for "${node.provider}"`,
+            );
+          const substitutions = {
+            prompt,
+            model: modelCfg?.apiModel || modelCfg?.value || "",
+            image_url: inputImg || "",
+          };
+          const body = {
+            provider: node.provider,
+            model: modelCfg?.value || "",
+            submit_url:
+              String(spec.base || "").replace(/\/$/, "") +
+              (modeSpec.submitPath || ""),
+            submit_body: this._fillTemplate(modeSpec.body, substitutions),
+            task_id_path: spec.taskIdPath,
+            status_value_path: spec.statusValuePath,
+            status_success: spec.statusSuccess,
+            status_failure: spec.statusFailure,
+            error_message_path: spec.errorMessagePath ?? null,
+            output_path: spec.outputPath,
+            output_keys: spec.outputKeys,
+            error_code_path: spec.errorCodePath ?? null,
+            no_credits_code: spec.noCreditsCode ?? null,
+          };
           const resp = await fetch(`${apiBase}/generate/3d`, {
             method: "POST",
             headers,
@@ -899,12 +1513,7 @@
             throw new Error(er.error || `HTTP ${resp.status}`);
           }
           const data = await resp.json();
-          let urls = data.media_urls || [];
-          if (!urls.length) {
-            const jobId = data.id;
-            if (!jobId) throw new Error("3D submitted but no job id returned");
-            urls = await this._poll3d(apiBase, jobId, headers);
-          }
+          const urls = data.media_urls || [];
           node.output3d =
             urls.find((u) => /\.glb(\?|$)/i.test(u)) || urls[0] || null;
           node.output3dPoster =
@@ -912,7 +1521,7 @@
           node.outputImage = null;
           node.outputText = null;
           if (!node.output3d) throw new Error("No 3D model returned");
-          getAE()?._ensureModelViewer?.();
+          this._ensureModelViewer();
         } else {
           const body = {
             prompt,
@@ -944,9 +1553,14 @@
       } catch (err) {
         node._error = err.message || "Error";
       } finally {
+        if (node._elapsedTimer) {
+          clearInterval(node._elapsedTimer);
+          node._elapsedTimer = null;
+        }
         node.generating = false;
         btn.disabled = false;
         this._renderOutput(node);
+        this._scheduleSave();
       }
     }
 

--- a/engine/rust-api/src/main.rs
+++ b/engine/rust-api/src/main.rs
@@ -8,11 +8,14 @@ use std::io::Write;
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, State},
-    http::HeaderMap,
+    body::Body,
+    extract::{Path, Query, State},
+    http::{header, HeaderMap, StatusCode},
+    response::Response,
     routing::{get, post},
     Json, Router,
 };
+use serde::Deserialize;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::{info, Level};
@@ -62,6 +65,8 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/generate/video", post(generate_video))
         .route("/api/generate/video/{id}", get(video_status))
         .route("/api/generate/3d", post(generate_3d))
+        .route("/api/upload/tripo", post(upload_tripo_image))
+        .route("/api/proxy/model", get(proxy_model))
         .layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any))
         .layer(TraceLayer::new_for_http())
         .with_state(app_state);
@@ -162,6 +167,119 @@ async fn generate_3d(
         .ok_or_else(|| AppError(anyhow::anyhow!("3D generation requires a provider API key (X-Provider-Key)")))?;
     let response = task3d::run(payload, key).await?;
     Ok(Json(serde_json::to_value(response)?))
+}
+
+#[derive(Deserialize)]
+struct TripoImageUploadRequest {
+    image: String,
+}
+
+async fn upload_tripo_image(
+    headers: HeaderMap,
+    Json(payload): Json<TripoImageUploadRequest>,
+) -> AppResult<Json<serde_json::Value>> {
+    use base64::Engine;
+
+    let key = headers
+        .get("x-provider-key")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| AppError(anyhow::anyhow!("Tripo upload requires X-Provider-Key")))?;
+    let encoded = payload
+        .image
+        .strip_prefix("data:")
+        .ok_or_else(|| AppError(anyhow::anyhow!("Tripo upload requires a data URL")))?;
+    let (metadata, data) = encoded
+        .split_once(',')
+        .ok_or_else(|| AppError(anyhow::anyhow!("malformed image data URL")))?;
+    if !metadata.contains("base64") {
+        return Err(AppError(anyhow::anyhow!("image data URL must be base64")));
+    }
+    let mime = metadata.split(';').next().unwrap_or("image/jpeg");
+    let extension = match mime {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        _ => return Err(AppError(anyhow::anyhow!("Tripo supports JPEG or PNG input"))),
+    };
+    let bytes = base64::engine::general_purpose::STANDARD.decode(data.trim())?;
+    if bytes.len() > 20 * 1024 * 1024 {
+        return Err(AppError(anyhow::anyhow!("Tripo image input exceeds 20 MB")));
+    }
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(format!("node-input.{extension}"))
+        .mime_str(mime)?;
+    let form = reqwest::multipart::Form::new().part("file", part);
+    let response = reqwest::Client::new()
+        .post("https://api.tripo3d.ai/v2/openapi/upload")
+        .bearer_auth(key)
+        .multipart(form)
+        .send()
+        .await?;
+    let status = response.status();
+    let raw: serde_json::Value = response.json().await.unwrap_or_default();
+    if !status.is_success() || raw["code"].as_i64().unwrap_or(0) != 0 {
+        return Err(AppError(anyhow::anyhow!("Tripo upload failed: {raw}")));
+    }
+    let token = raw["data"]["image_token"]
+        .as_str()
+        .ok_or_else(|| AppError(anyhow::anyhow!("Tripo upload returned no image token")))?;
+    Ok(Json(serde_json::json!({
+        "file_token": token,
+        "file_type": extension,
+    })))
+}
+
+#[derive(Deserialize)]
+struct ModelProxyQuery {
+    url: String,
+}
+
+/// Fetch a generated model through the local API so browser viewers are not
+/// blocked by provider storage CORS policies.
+async fn proxy_model(Query(query): Query<ModelProxyQuery>) -> AppResult<Response> {
+    let url = reqwest::Url::parse(&query.url)?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(AppError(anyhow::anyhow!("model URL must use http or https")));
+    }
+    let host = url.host_str().unwrap_or_default().to_ascii_lowercase();
+    if host.is_empty() || host == "localhost" || host.ends_with(".localhost") {
+        return Err(AppError(anyhow::anyhow!("invalid model host")));
+    }
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        let private = match ip {
+            std::net::IpAddr::V4(ip) => ip.is_private() || ip.is_link_local(),
+            std::net::IpAddr::V6(ip) => ip.is_unique_local() || ip.is_unicast_link_local(),
+        };
+        if private || ip.is_loopback() || ip.is_unspecified() {
+            return Err(AppError(anyhow::anyhow!("invalid model host")));
+        }
+    }
+
+    let upstream = reqwest::Client::new().get(url).send().await?;
+    if !upstream.status().is_success() {
+        return Err(AppError(anyhow::anyhow!(
+            "model host returned HTTP {}",
+            upstream.status()
+        )));
+    }
+    if upstream.content_length().is_some_and(|length| length > 100 * 1024 * 1024) {
+        return Err(AppError(anyhow::anyhow!("model exceeds 100 MB proxy limit")));
+    }
+    let content_type = upstream
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .cloned()
+        .unwrap_or_else(|| header::HeaderValue::from_static("model/gltf-binary"));
+    let bytes = upstream.bytes().await?;
+    if bytes.len() > 100 * 1024 * 1024 {
+        return Err(AppError(anyhow::anyhow!("model exceeds 100 MB proxy limit")));
+    }
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CACHE_CONTROL, "private, max-age=3600")
+        .body(Body::from(bytes))?;
+    Ok(response)
 }
 
 fn append_mycontent_csv(prompt: &str, request_id: &str) {


### PR DESCRIPTION
- Add collapsed-by-default Node Canvas panel with persisted open/minimized state
- Persist Node Canvas workflows, generated outputs, pan/zoom, and selected nodes across refreshes
- Persist Storyboard Flow scenes, selected scene, generated media, edits, and cleared state across refreshes
- Add mini map plus zoom in/out controls to Node Canvas
- Make Reset View center and fit all canvas nodes
- Inherit previous Generate node settings for newly added Generate nodes, excluding instructions
- Improve 3D generation support for Node Canvas, including elapsed generation time
- Add model-viewer based 3D preview with proxy-backed model loading
- Add rendered poster support for 3D outputs and allow 3D outputs to feed image-input nodes via poster image
- Add Tripo image upload support for image-to-3D generation
- Add backend routes for Tripo image upload and same-origin 3D model proxying
- Style storyboard edit save/cancel buttons